### PR TITLE
Fixed Saleforce

### DIFF
--- a/AspNet.WebHooks.ConnectedService/Content/WebHookHandler.tt
+++ b/AspNet.WebHooks.ConnectedService/Content/WebHookHandler.tt
@@ -1,7 +1,9 @@
 ﻿<#@ template debug="true" hostSpecific="true" #>
 <#@ output extension=".cs" #>
 <#@ parameter name="ns" type="System.String" #>
+<#@ parameter name="classNamePrefix" type="System.String" #>
 <#@ parameter name="receiverName" type="System.String" #>
+<#@ parameter name="incomingType" type="System.String" #>
 using Microsoft.AspNet.WebHooks;
 using Newtonsoft.Json.Linq;
 using System.Linq;
@@ -9,7 +11,7 @@ using System.Threading.Tasks;
 
 namespace <#= ns #>.WebHookHandlers
 {
-    public class <#= receiverName #>WebHookHandler : WebHookHandler
+    public class <#= classNamePrefix #>WebHookHandler : WebHookHandler
     {
         public override Task ExecuteAsync(string receiver, WebHookHandlerContext context)
         {
@@ -18,7 +20,7 @@ namespace <#= ns #>.WebHookHandlers
 			{
 				// todo: replace this placeholder functionality with your own code
 				string action = context.Actions.First();
-				JObject incoming = context.GetDataOrDefault<JObject>();
+				<#= incomingType #> incoming = context.GetDataOrDefault<<#= incomingType #>>();
 			}
             
             return Task.FromResult(true);

--- a/AspNet.WebHooks.ConnectedService/Content/WebHooksConnectedServiceConfig.json
+++ b/AspNet.WebHooks.ConnectedService/Content/WebHooksConnectedServiceConfig.json
@@ -41,7 +41,10 @@
     },
     {
       "name": "Salesforce",
-      "nugetPackage": "Microsoft.AspNet.WebHooks.Receivers.Salesforce"
+      "nugetPackage": "Microsoft.AspNet.WebHooks.Receivers.Salesforce",
+      "receiverNameOverride": "SfSoap",
+      "incomingTypeOverride": "SalesforceNotifications",
+      "receiverSecretConfigSettingNameOverride": "SalesforceSoap"
     },
     {
       "name": "Slack",

--- a/AspNet.WebHooks.ConnectedService/Handler.cs
+++ b/AspNet.WebHooks.ConnectedService/Handler.cs
@@ -59,24 +59,34 @@ namespace AspNet.WebHooks.ConnectedService
 
                     InstallPackage(item.Option.NuGetPackage, item.Option.NuGetVersionOverride);
 
-                    var receiverName = ((string.IsNullOrEmpty(item.Option.ConfigWireupOverride))
+                    var classNamePrefix = ((string.IsNullOrEmpty(item.Option.ConfigWireupOverride))
                                     ? item.Option.Name
                                     : item.Option.ConfigWireupOverride);
+
+                    var receiverName = ((string.IsNullOrEmpty(item.Option.ReceiverNameOverride))
+                                    ? classNamePrefix
+                                    : item.Option.ReceiverNameOverride);
+
+                    var incomingType = ((string.IsNullOrEmpty(item.Option.IncomingTypeOverride))
+                                    ? "JObject"
+                                    : item.Option.IncomingTypeOverride);
 
                     // add the handler code to the project
                     await GeneratedCodeHelper
                         .GenerateCodeFromTemplateAndAddToProject(
                             context,
                             "WebHookHandler",
-                            string.Format($@"WebHookHandlers\{receiverName}WebHookHandler.cs"),
+                            string.Format($@"WebHookHandlers\{classNamePrefix}WebHookHandler.cs"),
                             new Dictionary<string, object>
                             {
                                 {"ns", projectNamespace},
-                                {"receiverName", receiverName }
+                                {"classNamePrefix", classNamePrefix },
+                                {"receiverName", receiverName },
+                                {"incomingType", incomingType }
                             });
 
                     // remember this provider
-                    providers.Add(receiverName);
+                    providers.Add(classNamePrefix);
 
                     // record the telemetry for the receiver
                     TelemetryWrapper.RecordEvent($"{item.Option.Name}");

--- a/AspNet.WebHooks.ConnectedService/ViewModels/WebHookReceiverOption.cs
+++ b/AspNet.WebHooks.ConnectedService/ViewModels/WebHookReceiverOption.cs
@@ -8,6 +8,9 @@ namespace AspNet.WebHooks.ConnectedService.ViewModels
         public string NuGetPackage { get; set; }
         public string NuGetVersionOverride { get; set; }
         public string ConfigWireupOverride { get; set; }
+        public string ReceiverNameOverride { get; set; }
+        public string IncomingTypeOverride { get; set; }
+        public string ReceiverSecretConfigSettingNameOverride { get; set; }
 
         private bool _isChecked;
         public bool IsChecked

--- a/AspNet.WebHooks.ConnectedService/ViewModels/WebHookReceiverSecret.cs
+++ b/AspNet.WebHooks.ConnectedService/ViewModels/WebHookReceiverSecret.cs
@@ -32,9 +32,9 @@ namespace AspNet.WebHooks.ConnectedService.ViewModels
         {
             get
             {
-                var receiverName = ((string.IsNullOrEmpty(Option.ConfigWireupOverride))
-                                    ? Option.Name
-                                    : Option.ConfigWireupOverride);
+                var receiverName = string.IsNullOrEmpty(Option.ReceiverSecretConfigSettingNameOverride)
+                    ? (string.IsNullOrEmpty(Option.ConfigWireupOverride) ? Option.Name : Option.ConfigWireupOverride)
+                    : Option.ReceiverSecretConfigSettingNameOverride;
 
                 return string.Concat(Constants.ReceiverSecretConfigPrefix, receiverName);
             }


### PR DESCRIPTION
I was trying to use the `AspNet.WebHooks.ConnectedService` to setup Salesforce but was very confused. I eventually figured it out using [this post](http://blogs.msdn.com/b/webdev/archive/2015/09/07/integrating-with-salesforce-using-asp-net-webhooks-preview.aspx). The pull request adds some template variables and corrects the generated handler for Salesforce. Some of the other receivers might want to use this too but I haven't gone through them all.